### PR TITLE
Add ubuntu source for installing new version unconv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ MAINTAINER Geir Gåsodden
 
 #### Begin setup ####
 
+# Add ubuntu source to upgrade new version of unoconv. Debian jessie still uses old version.
+RUN echo "deb http://us.archive.ubuntu.com/ubuntu xenial main universe" >> /etc/apt/sources.list
+
 # Installs git and unoconv
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git unoconv && apt-get clean
 


### PR DESCRIPTION
Add ubuntu source to upgrade new version of unoconv. Debian jessie still uses old version

Related PR in tfk-api-unoconv https://github.com/zrrrzzt/tfk-api-unoconv/pull/23